### PR TITLE
Fix validation issue allowing empty datadog_site

### DIFF
--- a/vss-extension-dev.json
+++ b/vss-extension-dev.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "ci-visibility-dev",
-    "version": "0.0.5",
+    "version": "0.0.7",
     "name": "Datadog CI Visibility DEV",
     "publisher": "datadog",
     "public": false,
@@ -79,11 +79,16 @@
                 "inputDescriptors": [
                     {
                         "id": "datadog_site",
-                        "isRequired": true,
                         "name": "Datadog Site",
                         "description": "Datadog Site to send data to",
-                        "valueHint": "datadoghq.com",
-                        "inputMode": "textbox"
+                        "inputMode": "textbox",
+                        "values": {
+                            "defaultValue": "datadoghq.com"
+                        },
+                        "validation": {
+                            "dataType": "string",
+                            "isRequired": true
+                        }
                     },
                     {
                         "id": "api_key",
@@ -91,11 +96,12 @@
                         "name": "Datadog API Key",
                         "description": "Datadog API Key",
                         "inputMode": "passwordBox",
+                        "isConfidential": true,
                         "validation": {
                             "dataType": "string",
                             "isRequired": true,
                             "minLength": 32
-                          }
+                        }
                     }
                 ],
                 "actions": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "ci-visibility",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "name": "Datadog CI Visibility",
     "publisher": "datadog",
     "public": true,
@@ -76,11 +76,16 @@
                 "inputDescriptors": [
                     {
                         "id": "datadog_site",
-                        "isRequired": true,
                         "name": "Datadog Site",
                         "description": "Datadog Site to send data to",
-                        "valueHint": "datadoghq.com",
-                        "inputMode": "textbox"
+                        "inputMode": "textbox",
+                        "values": {
+                            "defaultValue": "datadoghq.com"
+                        },
+                        "validation": {
+                            "dataType": "string",
+                            "isRequired": true
+                        }
                     },
                     {
                         "id": "api_key",
@@ -88,11 +93,12 @@
                         "name": "Datadog API Key",
                         "description": "Datadog API Key",
                         "inputMode": "passwordBox",
+                        "isConfidential": true,
                         "validation": {
                             "dataType": "string",
                             "isRequired": true,
                             "minLength": 32
-                          }
+                        }
                     }
                 ],
                 "actions": [


### PR DESCRIPTION
What does this PR do?
---------------------

- We've had some support tickets caused by the integration settings allowing an empty datadog site and the placeholder text makes it look like the value might be set by default.
- This changes it so that instead of a placeholder it now is actually filled by default and it's also required so it cannot be left empty


